### PR TITLE
Add charmcraft.yaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 # TARGETS
 charm: clean ## Build the charm
-	charmcraft build
+	charmcraft pack
+	cp jobbergate-cli_ubuntu-20.04-amd64_centos-7-amd64.charm jobbergate-cli.charm
 
 lint: ## Run linter
 	tox -e lint
@@ -8,7 +9,7 @@ lint: ## Run linter
 
 clean: ## Remove .tox and build dirs
 	rm -rf .tox/ venv/ build/
-	rm -f jobbergate-cli.charm
+	rm -f *.charm
 
 
 format:

--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ Follow the steps below to get started.
 
 ### Build the charm
 
-Running the following command will produce a .charm file, `jobbergate-cli.charm`
+Running the following command will produce a `.charm` file, `jobbergate-cli.charm`:
+
 ```bash
-charmcraft build
+$ make charm
 ```
 
 ### Create the jobbergate-cli charm config

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -1,0 +1,12 @@
+type: charm
+bases:
+  - build-on:
+      - name: ubuntu
+        channel: "20.04"
+    run-on:
+      - name: ubuntu
+        channel: "20.04"
+        architectures: [amd64]
+      - name: centos
+        channel: "7"
+        architectures: [amd64]


### PR DESCRIPTION
With charmcraft 1.1.0, we need another YAML file in the repository,
charmcraft.yaml, that describes how to build and which OSes the charm
run. This patch adds the YAML file to build the charm on Ubuntu Focal
and run on Ubuntu Focal and CentOS7.