### PR TITLE
Add status update to end of upgrade action

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -52,10 +52,10 @@ class JobbergateCliCharm(CharmBase):
         try:
             self._jobbergate_cli_ops.upgrade(version)
             event.set_results({"upgrade": "success"})
+            self.unit.status = ActiveStatus(f"Updated to version {version}")
         except Exception:
-            self.unit.status = BlockedStatus("Error upgrading jobbergate-cli")
-            event.fail(message="Error upgrading jobbergate-cli")
-            event.defer()
+            self.unit.status = BlockedStatus(f"Error updating to version {version}")
+            event.fail()
 
     def _on_config_changed(self, event):
         """Configure jobbergate-cli."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -49,7 +49,13 @@ class JobbergateCliCharm(CharmBase):
 
     def _on_upgrade_action(self, event):
         version = event.params["version"]
-        self._jobbergate_cli_ops.upgrade(version)
+        try:
+            self._jobbergate_cli_ops.upgrade(version)
+            event.set_results({"upgrade": "success"})
+        except Exception:
+            self.unit.status = BlockedStatus("Error upgrading jobbergate-cli")
+            event.fail(message="Error upgrading jobbergate-cli")
+            event.defer()
 
     def _on_config_changed(self, event):
         """Configure jobbergate-cli."""


### PR DESCRIPTION
Each of the juju charms should update their statuses at the end of the upgrade action. Otherwise, we have to wait for 5 minutes for juju to run another check.

https://app.clickup.com/t/18022949/ARMADA-852