### PR TITLE
Add versioning to the legacy jobbergate-cli charm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,17 @@
 # TARGETS
-charm: clean ## Build the charm
-	charmcraft pack
-	cp jobbergate-cli_ubuntu-20.04-amd64_centos-7-amd64.charm jobbergate-cli.charm
+charm: clean version ## Build the charm
+	@charmcraft pack
+	@cp jobbergate-cli_ubuntu-20.04-amd64_centos-7-amd64.charm jobbergate-cli.charm
 
 lint: ## Run linter
 	tox -e lint
 
+version: ## Create/update version file
+	@git describe --tags --dirty --always > version
 
 clean: ## Remove .tox and build dirs
 	rm -rf .tox/ venv/ build/
 	rm -f *.charm
-
 
 format:
 	isort src

--- a/src/charm.py
+++ b/src/charm.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """JobbergateCLICharm"""
 import logging
+from pathlib import Path
 
 from ops.charm import CharmBase
 from ops.framework import StoredState
@@ -28,6 +29,7 @@ class JobbergateCliCharm(CharmBase):
 
         event_handler_bindings = {
             self.on.install: self._on_install,
+            self.on.upgrade_charm: self._on_upgrade,
             self.on.config_changed: self._on_config_changed,
             self.on.remove: self._on_remove,
             self.on.upgrade_action: self._on_upgrade_action,
@@ -37,11 +39,16 @@ class JobbergateCliCharm(CharmBase):
 
     def _on_install(self, event):
         """Install jobbergate-cli."""
+        self.unit.set_workload_version(Path("version").read_text().strip())
         self._jobbergate_cli_ops.install()
         self._stored.installed = True
         # Log and set status
         logger.debug("jobbergate-cli installed")
         self.unit.status = ActiveStatus("jobbergate-cli installed")
+
+    def _on_upgrade(self, event):
+        """Perform upgrade operations."""
+        self.unit.set_workload_version(Path("version").read_text().strip())
 
     def _on_remove(self, event):
         """Remove directories and files created by jobbergate-cli charm."""


### PR DESCRIPTION
**What**

Set the version on install and upgrade events.

**Why**

It is needed to keep track of the charm version.