### PR TITLE
Add an action to show the version of jobbergate-cli

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -7,3 +7,7 @@ upgrade:
       description: Version of jobbergate-cli to upgrade to.
   required:
     - version
+
+show-version:
+  description: >
+    Display the version and information about jobbergate-cli.

--- a/src/charm.py
+++ b/src/charm.py
@@ -33,6 +33,7 @@ class JobbergateCliCharm(CharmBase):
             self.on.config_changed: self._on_config_changed,
             self.on.remove: self._on_remove,
             self.on.upgrade_action: self._on_upgrade_action,
+            self.on.show_version_action: self._on_show_version_action,
         }
         for event, handler in event_handler_bindings.items():
             self.framework.observe(event, handler)
@@ -63,6 +64,11 @@ class JobbergateCliCharm(CharmBase):
         except Exception:
             self.unit.status = BlockedStatus(f"Error updating to version {version}")
             event.fail()
+
+    def _on_show_version_action(self, event):
+        """Show the info and version of jobbergate-cli."""
+        info = self._jobbergate_cli_ops.get_version_info()
+        event.set_results({"jobbergate-cli": info})
 
     def _on_config_changed(self, event):
         """Configure jobbergate-cli."""

--- a/src/jobbergate_cli_ops.py
+++ b/src/jobbergate_cli_ops.py
@@ -107,6 +107,18 @@ class JobbergateCliOps:
         else:
             logger.debug(f"{self._PACKAGE_NAME} installed")
 
+    def get_version_info(self):
+        """Show version and info about jobbergate-cli."""
+        cmd = [
+            self._PIP_CMD,
+            "show",
+            self._PACKAGE_NAME
+        ]
+
+        out = subprocess.check_output(cmd, env={}).decode().strip()
+
+        return out
+
     def remove(self):
         """
         Remove the things we have created.


### PR DESCRIPTION
**What**

Add an action named _show-version_ to display all information returned by `pip show jobbergate-cli`, which includes the version of the package.

Usage: `juju run-action jobbergate-cli/leader show-version --wait`

**Why**

With that, we can easily check the version and relate information about the software without the need to log in to the node.