### PR TITLE
Add an action to show the version of new-jobbergate-cli 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,4 +6,6 @@ This file keeps track of all notable changes to charm-jobbergate-cli
 
 Unreleased
 ----------
+
+- Added an action to show the version of new-jobbergate-cli.
 - Started versioning the charm.

--- a/actions.yaml
+++ b/actions.yaml
@@ -7,3 +7,7 @@ upgrade:
       description: Version of new-jobbergate-cli to upgrade to.
   required:
     - version
+
+show-version:
+  description: >
+    Display the version and information about new-jobbergate-cli.

--- a/src/charm.py
+++ b/src/charm.py
@@ -32,6 +32,7 @@ class JobbergateCliCharm(CharmBase):
             self.on.config_changed: self._on_config_changed,
             self.on.remove: self._on_remove,
             self.on.upgrade_action: self._on_upgrade_action,
+            self.on.show_version_action: self._on_show_version_action,
         }
         for event, handler in event_handler_bindings.items():
             self.framework.observe(event, handler)
@@ -63,6 +64,11 @@ class JobbergateCliCharm(CharmBase):
         except Exception:
             self.unit.status = BlockedStatus(f"Error updating to version {version}")
             event.fail()
+
+    def _on_show_version_action(self, event):
+        """Show the info and version of new-jobbergate-cli."""
+        info = self._jobbergate_cli_ops.get_version_info()
+        event.set_results({"new-jobbergate-cli": info})
 
     def _on_config_changed(self, event):
         """Configure jobbergate-cli."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -29,6 +29,7 @@ class JobbergateCliCharm(CharmBase):
 
         event_handler_bindings = {
             self.on.install: self._on_install,
+            self.on.upgrade_charm: self._on_upgrade,
             self.on.config_changed: self._on_config_changed,
             self.on.remove: self._on_remove,
             self.on.upgrade_action: self._on_upgrade_action,

--- a/src/jobbergate_cli_ops.py
+++ b/src/jobbergate_cli_ops.py
@@ -97,6 +97,20 @@ class JobbergateCliOps:
         else:
             logger.debug(f"{self._PACKAGE_NAME} installed")
 
+    def get_version_info(self):
+        """Show version and info about new-jobbergate-cli."""
+        cmd = [
+            self._VENV_PYTHON,
+            "-m",
+            "pip",
+            "show",
+            self._PACKAGE_NAME
+        ]
+
+        out = subprocess.check_output(cmd, env={}).decode().strip()
+
+        return out
+
     def remove(self):
         """
         Remove the things we have created.


### PR DESCRIPTION
**What**

Add an action named `show-version` to display all information returned by `pip show new-jobbergate-cli`, which includes the version of the package.

Usage: `juju run-action new-jobbergate-cli/leader show-version --wait`

**Why**

With that, we can easily check the version and relate information about the software without the need to log in to the node.