### PR TITLE
Set jobbergate-cli to run with Python 3.8

### DIFF
--- a/dispatch
+++ b/dispatch
@@ -6,30 +6,40 @@ set -e
 # Source the os-release information into the env.
 . /etc/os-release
 
-if ! [[ -f '.installed' ]]; then
+PYTHON_BIN=/opt/python/3.8.16/bin/python3.8
+
+if [ ! -f '.installed' ]
+then
     # Determine if we are running in centos or ubuntu, if centos
     # provision the needed prereqs.
-    if [[ $ID == 'centos' ]]; then
-        yum -y install wget
-        # Determine the centos version and install prereqs accordingly
-        major=$(cat /etc/centos-release | tr -dc '0-9.'|cut -d \. -f1)
-        if [[ $major == "7" ]]; then
-            # Install yaml deps
-            yum -y install libyaml-devel
-            # Install python3 using yum (will install python3.6 on centos7)
-            if ! type -a python3; then
-                echo "Running centos$major, installing prereqs."
-                # Install system python3
-                yum -y install epel-release
-                yum -y install python3
-            fi
-        else
-            echo "Running unsuppored version of centos: $major"
-            exit -1
+    if [ $ID = 'centos' || $ID = 'rocky' ]
+    then       
+        # Install yaml deps
+        yum -y install libyaml-devel
+        
+        # We need python3.8 to run license-manager-agent.
+        # Install python3.8 from source.
+        if [ ! -e $PYTHON_BIN ]
+        then
+            yum install -y epel-release gcc zlib-devel bzip2 bzip2-devel readline-devel \
+            sqlite sqlite-devel openssl-devel tk-devel libffi-devel xz-devel wget
+
+            /bin/bash ./src/templates/install_python.sh
+        fi       
+    elif [ $ID = 'ubuntu' ]
+    then
+        # We are running an ubuntu os, so check for python and install the
+        # needed venv package or python3 from source, depending on what already
+        # exists on the system.
+        #
+        if [ ! -e $PYTHON_BIN ]
+        then
+            apt install -y make build-essential libssl-dev zlib1g-dev \
+            libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
+            libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
+
+            /bin/bash ./src/templates/install_python.sh        
         fi
-    elif [[ $ID == 'ubuntu' ]]; then
-        # pip and venv are not installed in ubuntu by default. Install them
-        apt install -y python3-pip python3-venv
     fi
     touch .installed
 fi

--- a/dispatch
+++ b/dispatch
@@ -12,7 +12,7 @@ if [ ! -f '.installed' ]
 then
     # Determine if we are running in centos or ubuntu, if centos
     # provision the needed prereqs.
-    if [ $ID = 'centos' || $ID = 'rocky' ]
+    if [[ $ID == 'centos' || $ID == 'rocky' ]]
     then       
         # Install yaml deps
         yum -y install libyaml-devel
@@ -26,7 +26,7 @@ then
 
             /bin/bash ./src/templates/install_python.sh
         fi       
-    elif [ $ID = 'ubuntu' ]
+    elif [ $ID == 'ubuntu' ]
     then
         # We are running an ubuntu os, so check for python and install the
         # needed venv package or python3 from source, depending on what already

--- a/src/jobbergate_cli_ops.py
+++ b/src/jobbergate_cli_ops.py
@@ -15,7 +15,7 @@ logger = logging.getLogger()
 class JobbergateCliOps:
     """Track and perform jobbergate-cli ops."""
 
-    _PYTHON_BIN = Path("/usr/bin/python3")
+    _PYTHON_BIN = Path("/opt/python/3.8.16/bin/python3.8")
     _PACKAGE_NAME = "jobbergate-cli"
     _VENV_DIR = Path("/srv/new-jobbergate-cli-venv")
     _VENV_PYTHON = _VENV_DIR.joinpath("bin", "python").as_posix()

--- a/src/templates/install_python.sh
+++ b/src/templates/install_python.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+export PYTHON_VERSION=3.8.16
+wget https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tar.xz -P /tmp
+tar xvf /tmp/Python-${PYTHON_VERSION}.tar.xz -C /tmp/
+cd /tmp/Python-${PYTHON_VERSION}
+./configure --enable-optimizations --prefix=/opt/python/${PYTHON_VERSION}
+make altinstall
+cd /tmp
+rm -rf ./Python*


### PR DESCRIPTION
**What**

- Build a custom Python 3.8 installation.
- Set jobbergate-cli to run with the custom python.

**Why**

Drop support for Python < 3.8.
Keep compatibility across Centos, Rocky, and Ubuntu.
