### PR TITLE
feat: add new configuration CACHE_DIR

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Unreleased
 ----------
 - Added new configuration: JOBBERGATE_LEGACY_NAME_CONVENTION
 - Added new configuration: SBATCH_PATH [ASP-4238]
+- Added new configuration: JOBBERGATE_CACHE_DIR [ASP-4053]
 
 1.0.3 - 2023-09-07
 ------------------

--- a/config.yaml
+++ b/config.yaml
@@ -69,6 +69,11 @@ options:
     default: /usr/bin/sbatch
     description: |
       Location of the sbatch executable used to enable on-site submissions.
+  cache-dir:
+    type: string
+    default: ~/.local/share/jobbergate
+    description: |
+      Location for the cache dir that can be set for each environment to avoid conflicts on access credentials.
   alias-name:
     type: string
     default: "jobbergate"

--- a/src/charm.py
+++ b/src/charm.py
@@ -89,6 +89,7 @@ class JobbergateCliCharm(CharmBase):
             "legacy-name-convention",
             "default-cluster-name",
             "sbatch-path",
+            "cache-dir",
             "alias-name",
         }
         ctxt = {k: self.model.config.get(k) for k in ctxt_keys}


### PR DESCRIPTION
It allows setting a different cache location for each environment (QA, staging, prod), avoing conclicts on access credentials.