### PR TITLE
fix: Remove CentOS 8 support

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -12,3 +12,4 @@ bases:
         architectures: [amd64]
       - name: centos
         channel: "7"
+        architectures: [amd64]

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -12,7 +12,3 @@ bases:
         architectures: [amd64]
       - name: centos
         channel: "7"
-        architectures: [amd64]
-      - name: centos
-        channel: "8"
-        architectures: [amd64]


### PR DESCRIPTION
CentOS is no longer supported by Juju.