### PR TITLE
[ASP-4624] Use Jobbergate-cli charm to install shell autocompletion

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ This file keeps track of all notable changes to charm-jobbergate-cli
 
 Unreleased
 ----------
+- Enabled shell completion for the jobbergate-cli [ASP-4624]
+- Removed alias name now that legacy is decommissioned, create a symlink on `/usr/local/bin` instead
 
 1.0.6 - 2024-07-01
 ------------------

--- a/config.yaml
+++ b/config.yaml
@@ -69,11 +69,6 @@ options:
     default: ~/.local/share/jobbergate
     description: |
       Location for the cache dir that can be set for each environment to avoid conflicts on access credentials.
-  alias-name:
-    type: string
-    default: "jobbergate"
-    description: |
-      Executable name set using an alias in order to avoid conflicts with legacy jobbergate.
   multi-tenancy-enabled:
     type: boolean
     default: true

--- a/src/charm.py
+++ b/src/charm.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """JobbergateCLICharm"""
+
 import logging
 from pathlib import Path
 
@@ -90,7 +91,6 @@ class JobbergateCliCharm(CharmBase):
             "default-cluster-name",
             "sbatch-path",
             "cache-dir",
-            "alias-name",
             "multi-tenancy-enabled",
         }
         ctxt = {k: self.model.config.get(k) for k in ctxt_keys}
@@ -107,9 +107,6 @@ class JobbergateCliCharm(CharmBase):
             self._stored.backend_base_url = backend_base_url
 
         self._jobbergate_cli_ops.configure_etc_default(ctxt)
-        self._jobbergate_cli_ops.configure_executable_alias(
-            alias_name=ctxt.get("alias-name", "jobbergate")
-        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* Replaced previsous `jobbergate` alias by a symlink on `/user/local/bin`. The alias was used to avoid conflicts with jobbergate-legacy, so it is not needed anymore. Symlink is required for shell autocompletion.
* Enable shell autocompletion for bash.